### PR TITLE
Update Makefile

### DIFF
--- a/espresso-src/Makefile
+++ b/espresso-src/Makefile
@@ -8,7 +8,7 @@ TARGET := $(TARGETDIR)/espresso
 all: prepare $(TARGET)
 
 prepare:
-	mkdir $(TARGETDIR)
+	mkdir -p $(TARGETDIR)
 
 $(TARGET): $(OBJ)
 	$(LINK.c) $(OBJ) -o $(TARGET)


### PR DESCRIPTION
`mkdir` fails when target exists unless the -p argument is provided