### PR TITLE
Don't redefine strdup

### DIFF
--- a/espresso-src/strdup.c
+++ b/espresso-src/strdup.c
@@ -1,6 +1,7 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifndef strdup
 char *strdup(const char * src) {
   char * dup;
   unsigned int len;
@@ -18,3 +19,4 @@ char *strdup(const char * src) {
 
   return dup;
 }
+#endif


### PR DESCRIPTION
A strdup() implementation was added in the commit listed below.  The header has a guarded declaration, but it's missing from the corresponding definition in the source file.

commit 5b1be463b360bcc5c618a4ecb1c6f775d74c3c07